### PR TITLE
Add udev rule and system-sleep script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ configure_file(
     ${PROJECT_SOURCE_DIR}/system/99-ir-led.rules.cmake
     ${PROJECT_BINARY_DIR}/system/99-ir-led.rules
 )
+configure_file(
+    ${PROJECT_SOURCE_DIR}/system/ir-led.sh.cmake
+    ${PROJECT_BINARY_DIR}/system/ir-led.sh
+)
+
 
 add_executable(${PROJECT_NAME} main.c)
 
@@ -13,3 +18,5 @@ install(TARGETS ${PROJECT_NAME}
 
 install(FILES ${PROJECT_BINARY_DIR}/system/99-ir-led.rules
 		DESTINATION /lib/udev/rules.d/)
+install(PROGRAMS ${PROJECT_BINARY_DIR}/system/ir-led.sh
+		DESTINATION /lib/systemd/system-sleep)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ configure_file(
 
 add_executable(${PROJECT_NAME} main.c)
 
-install(TARGETS ${PROJECT_NAME})
+install(TARGETS ${PROJECT_NAME}
+	RUNTIME DESTINATION bin)
 
 install(FILES ${PROJECT_BINARY_DIR}/system/99-ir-led.rules
 		DESTINATION /lib/udev/rules.d/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,14 @@
-# cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 2.8.9)
 project(chicony-ir-toggle)
+
+configure_file(
+    ${PROJECT_SOURCE_DIR}/system/99-ir-led.rules.cmake
+    ${PROJECT_BINARY_DIR}/system/99-ir-led.rules
+)
 
 add_executable(${PROJECT_NAME} main.c)
 
 install(TARGETS ${PROJECT_NAME})
+
+install(FILES ${PROJECT_BINARY_DIR}/system/99-ir-led.rules
+		DESTINATION /lib/udev/rules.d/)

--- a/system/99-ir-led.rules.cmake
+++ b/system/99-ir-led.rules.cmake
@@ -1,0 +1,1 @@
+ATTRS{idVendor}=="04f2", ATTRS{idProduct}=="b67c", ACTION=="add", RUN+="@CMAKE_INSTALL_PREFIX@/bin/chicony-ir-toggle on"

--- a/system/ir-led.sh.cmake
+++ b/system/ir-led.sh.cmake
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Enable IR emitter after waking from suspend/hibernation
+case $1 in
+    post)
+	$CMAKE_INSTALL_PREFIX@/bin/chicony-ir-toggle on
+	;;
+esac

--- a/system/ir-led.sh.cmake
+++ b/system/ir-led.sh.cmake
@@ -3,6 +3,6 @@
 # Enable IR emitter after waking from suspend/hibernation
 case $1 in
     post)
-	$CMAKE_INSTALL_PREFIX@/bin/chicony-ir-toggle on
+	@CMAKE_INSTALL_PREFIX@/bin/chicony-ir-toggle on
 	;;
 esac


### PR DESCRIPTION
Add udev rule to execute script after the device has loaded and a systemd-script that executes the script after waking from sleep/hibernation. Fixes #2.